### PR TITLE
Fixed a leak in encodeQueryString

### DIFF
--- a/KISSmetricsAPI/KMAQueryEncoder.m
+++ b/KISSmetricsAPI/KMAQueryEncoder.m
@@ -72,10 +72,10 @@ static NSString * const kKMAAliasPath = @"/a";
 
 - (NSString*)encodeQueryString:(NSString*)queryString
 {
-    NSString * encoded = (__bridge NSString *)CFURLCreateStringByAddingPercentEscapes(NULL,
+    NSString * encoded = CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,
                                                                                       (CFStringRef)queryString, NULL,
                                                                                       (CFStringRef)@"!*'();:@&=+$,/?%#[]",
-                                                                                      kCFStringEncodingUTF8 );
+                                                                                      kCFStringEncodingUTF8 ));
     return encoded;
 }
 


### PR DESCRIPTION
There was some incorrect bridging here causing a lot of leaks. 

Added the proper bridging function for ARC CFBridgingRelease()

![Leaks in our project](http://i.imgur.com/sN5WEsK.png)