### PR TITLE
Fix crash on sendTopRecord

### DIFF
--- a/KISSmetricsAPI/KMASenderReadyState.m
+++ b/KISSmetricsAPI/KMASenderReadyState.m
@@ -34,9 +34,15 @@
 #pragma mark - Private methods
 - (void)sendTopRecord
 {
+    NSString *queryString = [[KMAArchiver sharedArchiver] getQueryStringAtIndex:0];
+
+    if (!queryString) {
+        return;
+    }
+
     // Assemble the full query string by prepending the current baseUrl as last archived.
     NSString *nextAPICall = [[KMAArchiver sharedArchiver] getBaseUrl];
-    nextAPICall = [nextAPICall stringByAppendingString:[[KMAArchiver sharedArchiver] getQueryStringAtIndex:0]];
+    nextAPICall = [nextAPICall stringByAppendingString:queryString];
     KMAConnection *connection = [self.sender getNewConnection];
     [connection sendRecordWithURLString:nextAPICall delegate:self.sender];
 }


### PR DESCRIPTION
This crash was occurring on setup of Kissmetrics 

```
Thread : Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x1816c1900 __exceptionPreprocess
1  libobjc.A.dylib                0x180d2ff80 objc_exception_throw
2  CoreFoundation                 0x1816c1848 -[NSException initWithCoder:]
3  Foundation                     0x181f9d298 -[NSString stringByAppendingString:]
4  dice                           0x1007c3bbc -[KMASenderReadyState sendTopRecord]
5  dice                           0x1007c3e4c __35-[KMASenderReadyState startSending]_block_invoke
6  Foundation                     0x182068334 __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__
7  Foundation                     0x181fbb100 -[NSBlockOperation main]
8  Foundation                     0x181fab348 -[__NSOperationInternal _start:]
9  Foundation                     0x18206a728 __NSOQSchedule_f
10 libdispatch.dylib              0x1811155f0 _dispatch_client_callout
11 libdispatch.dylib              0x181121634 _dispatch_queue_drain
12 libdispatch.dylib              0x1811190f4 _dispatch_queue_invoke
13 libdispatch.dylib              0x181123504 _dispatch_root_queue_drain
14 libdispatch.dylib              0x181123224 _dispatch_worker_thread3
15 libsystem_pthread.dylib        0x181329470 _pthread_wqthread
16 libsystem_pthread.dylib        0x181329020 start_wqthread
```