### PR TITLE
[FIX] Handle also the connection error that are not malformed so not stuck on SendingState.

### DIFF
--- a/KISSmetricsAPI/KMAConnection.m
+++ b/KISSmetricsAPI/KMAConnection.m
@@ -141,6 +141,8 @@ static float const kKMAConnectionTimeout = 20.0f;
             error.code == NSURLErrorDataLengthExceedsMaximum) {
             
             [self.delegate connectionSuccessful:NO forUrlString:_urlString isMalformedRequest:YES];
+        }else{
+            [self.delegate connectionSuccessful:NO forUrlString:_urlString isMalformedRequest:NO];
         }
     }
     


### PR DESCRIPTION
Need to all errors and return to delegate that it failed like in `- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response
`
so the KMASender change back to ReadyState. If the error is not handled when the device is offline the error is of type -1009(timeout) and then it never tries to send the reports even when device back online cause the KMASender is in SendingState.