### PR TITLE
Fix AutorecordInstalls / Updated App bug

### DIFF
--- a/KISSmetricsAPI/KISSmetricsAPI.m
+++ b/KISSmetricsAPI/KISSmetricsAPI.m
@@ -341,6 +341,7 @@ static NSString *kKMASystemVersionPropertyKey = @"System Version";
         // If the existing value doesn't match the current, this is an update.
         if (![[[KMAArchiver sharedArchiver] keychainAppVersion] isEqualToString:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"]]) {
             [sharedAPI record:kKMAAppUpdatedEventName];
+            [[KMAArchiver sharedArchiver] setKeychainAppVersion:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"]];
         }
     }
 }


### PR DESCRIPTION
Current behavior: `Updated App` is sent for every app launch in which the user's app version is not equal to the first installed version
E.G.
```
User launches 1.0 -> Installed App     // correct behavior
User launches 1.0 -> <No event sent>   // correct behavior
User launches 1.1 -> Updated App       // correct behavior
User launches 1.1 -> Updated App       // *incorrect* behavior - expected no event sent
```
Expected behavior: Updated App is only sent on the first launch after the app is updated.

This update fixes the issue by recording the latest app version when an update is detected.